### PR TITLE
feat(physics) calculo de colisiones reemplazado

### DIFF
--- a/.idea/.idea.DesarrolloMobile/.idea/indexLayout.xml
+++ b/.idea/.idea.DesarrolloMobile/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/Assets/PaddleBounceVisualizer.cs
+++ b/Assets/PaddleBounceVisualizer.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+
+[ExecuteAlways]
+[RequireComponent(typeof(Transform))]
+public class PaddleBounceVisualizer : MonoBehaviour
+{
+    [Header("Bounce Preview")]
+    [Range(0f, 90f)]
+    public float maxBounceAngle = 75f;
+
+    [Header("Ray Settings")]
+    public float rayLength = 2f;
+    public Color centerColor = Color.green;
+    public Color angleColor = Color.yellow;
+    public Color zoneColorStart = Color.red;
+    public Color zoneColorEnd = Color.green;
+
+    [Header("Impact Zones")]
+    [Range(1, 10)]
+    public int impactZoneLines = 7;
+    public float impactZoneWidth = 0.4f;
+
+    private void OnDrawGizmos()
+    {
+        Vector3 origin = transform.position;
+
+        DrawBounceAngleLines(origin);
+        DrawImpactZones(origin);
+    }
+
+    private void DrawBounceAngleLines(Vector3 origin)
+    {
+        // Línea central (recta hacia arriba)
+        Gizmos.color = centerColor;
+        Gizmos.DrawRay(origin, Vector3.up * rayLength);
+
+        // Líneas anguladas
+        Gizmos.color = angleColor;
+        DrawBounceAngleRay(origin, -maxBounceAngle);
+        DrawBounceAngleRay(origin, maxBounceAngle);
+    }
+
+    private void DrawBounceAngleRay(Vector3 origin, float angle)
+    {
+        float rad = angle * Mathf.Deg2Rad;
+        Vector3 direction = new Vector3(Mathf.Sin(rad), Mathf.Cos(rad), 0f).normalized;
+        Gizmos.DrawRay(origin, direction * rayLength);
+    }
+
+    private void DrawImpactZones(Vector3 origin)
+    {
+        if (impactZoneLines < 2) return;
+
+        float paddleHeight = transform.localScale.y;
+        int halfLines = impactZoneLines / 2;
+
+        for (int i = -halfLines; i <= halfLines; i++)
+        {
+            float t = (i + halfLines) / (float)(impactZoneLines - 1);
+            float yOffset = i * (paddleHeight / (impactZoneLines - 1));
+            Gizmos.color = Color.Lerp(zoneColorStart, zoneColorEnd, t);
+
+            Vector3 left = origin + Vector3.up * yOffset + Vector3.left * (impactZoneWidth / 2f);
+            Vector3 right = origin + Vector3.up * yOffset + Vector3.right * (impactZoneWidth / 2f);
+            Gizmos.DrawLine(left, right);
+        }
+    }
+}

--- a/Assets/PaddleBounceVisualizer.cs.meta
+++ b/Assets/PaddleBounceVisualizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 383f150344c231343a03d1d900543981
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Arkanoid/ArkanoidBall.prefab
+++ b/Assets/Prefabs/Arkanoid/ArkanoidBall.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6199170638837260914
+--- !u!1 &5206222243746660079
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,42 +8,39 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4013535886687311767}
-  - component: {fileID: 4228778957959196571}
-  - component: {fileID: 491961996993300662}
-  - component: {fileID: 9212702855680048538}
-  - component: {fileID: 5190349869590758810}
-  - component: {fileID: -997520957604314842}
-  - component: {fileID: 5469706416142032924}
+  - component: {fileID: 1173791524669793595}
+  - component: {fileID: 9041829928047503343}
+  - component: {fileID: 3200240217857465688}
+  - component: {fileID: 8783538167090626717}
   m_Layer: 0
-  m_Name: ArkanoidBall
+  m_Name: Capsule
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4013535886687311767
+--- !u!4 &1173791524669793595
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
+  m_GameObject: {fileID: 5206222243746660079}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.39, y: 0.78, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 4013535886687311767}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4228778957959196571
+--- !u!212 &9041829928047503343
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
+  m_GameObject: {fileID: 5206222243746660079}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -89,79 +86,13 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &491961996993300662
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.1
---- !u!114 &9212702855680048538
+--- !u!114 &3200240217857465688
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9228636f61fd15a448c3322d8393e1ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &5190349869590758810
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fc4e43937da5d4e4283a6692b37d8a24, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  collisionCheck: {fileID: 9212702855680048538}
-  ballData: {fileID: 11400000, guid: 82939cc4b1bf3634d8fbad5de23937fe, type: 2}
-  bounceScale: {x: 0.5, y: 0.5, z: 0.25}
-  particlesType: 2
-  bounceColor: {r: 1, g: 0.19607845, b: 0, a: 1}
-  animationLenght: 0.1
-  bounceSFX: 3
---- !u!114 &-997520957604314842
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
+  m_GameObject: {fileID: 5206222243746660079}
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f2251b651ddeed2489815f26b026e905, type: 3}
@@ -177,15 +108,15 @@ MonoBehaviour:
   alphaFluctuationDivisor: 74
   color: {r: 0, g: 0, b: 0, a: 0}
   ghostPrefabType: 9
---- !u!96 &5469706416142032924
+--- !u!96 &8783538167090626717
 TrailRenderer:
   serializedVersion: 3
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6199170638837260914}
-  m_Enabled: 0
+  m_GameObject: {fileID: 5206222243746660079}
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 0
@@ -290,3 +221,94 @@ TrailRenderer:
   m_Autodestruct: 1
   m_Emitting: 1
   m_ApplyActiveColorSpace: 0
+--- !u!1 &6199170638837260914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4013535886687311767}
+  - component: {fileID: 491961996993300662}
+  - component: {fileID: 5190349869590758810}
+  m_Layer: 0
+  m_Name: ArkanoidBall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4013535886687311767
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6199170638837260914}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.39, y: 0.78, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 1173791524669793595}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &491961996993300662
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6199170638837260914}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.125
+--- !u!114 &5190349869590758810
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6199170638837260914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc4e43937da5d4e4283a6692b37d8a24, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteRenderer: {fileID: 9041829928047503343}
+  visualTransform: {fileID: 1173791524669793595}
+  ballData: {fileID: 11400000, guid: 82939cc4b1bf3634d8fbad5de23937fe, type: 2}
+  minRandomX: -1
+  maxRandomX: 1
+  bounceScale: {x: 0.5, y: 0.5, z: 0.25}
+  particlesType: 2
+  bounceColor: {r: 1, g: 0.19607845, b: 0, a: 1}
+  animationLenght: 0.1
+  bounceSFX: 3

--- a/Assets/Prefabs/Paddle.prefab
+++ b/Assets/Prefabs/Paddle.prefab
@@ -9,12 +9,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5313984744809042107}
-  - component: {fileID: 1363461999555107373}
   - component: {fileID: 4985533727670356311}
   - component: {fileID: 632787481852008282}
-  - component: {fileID: 8505656643901065664}
-  - component: {fileID: -5948816004439429037}
-  - component: {fileID: 8055417595191393506}
   m_Layer: 9
   m_Name: Paddle
   m_TagString: Untagged
@@ -30,66 +26,15 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4623592075852294423}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -3.81, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 327145017433385037}
   - {fileID: 1651877366047296162}
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!212 &1363461999555107373
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4623592075852294423}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 02b8e083c72759d4f8836b4ce3676f6c, type: 3}
-  m_Color: {r: 0, g: 1, b: 0.9758296, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.34, y: 2.73}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4985533727670356311
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -136,7 +81,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.0016640201, y: 0}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -147,27 +92,114 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.14794911, y: 1}
+  m_Size: {x: 1, y: 0.12}
   m_EdgeRadius: 0
---- !u!114 &8505656643901065664
+--- !u!1 &5174908821584976142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 327145017433385037}
+  - component: {fileID: 4212597307800980295}
+  - component: {fileID: 2527248105951668731}
+  - component: {fileID: 8650504011632077831}
+  - component: {fileID: 4825845490952698290}
+  m_Layer: 9
+  m_Name: visual
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &327145017433385037
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5174908821584976142}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5313984744809042107}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!212 &4212597307800980295
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5174908821584976142}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 02b8e083c72759d4f8836b4ce3676f6c, type: 3}
+  m_Color: {r: 0, g: 1, b: 0.9758296, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.34, y: 2.73}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &2527248105951668731
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4623592075852294423}
+  m_GameObject: {fileID: 5174908821584976142}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9e47eecb573085f49919d7a2ad4c7cae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &-5948816004439429037
+--- !u!114 &8650504011632077831
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4623592075852294423}
+  m_GameObject: {fileID: 5174908821584976142}
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f2251b651ddeed2489815f26b026e905, type: 3}
@@ -183,14 +215,14 @@ MonoBehaviour:
   alphaFluctuationDivisor: 124
   color: {r: 0, g: 1, b: 0.97647065, a: 0.46666667}
   ghostPrefabType: 8
---- !u!96 &8055417595191393506
+--- !u!96 &4825845490952698290
 TrailRenderer:
   serializedVersion: 3
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4623592075852294423}
+  m_GameObject: {fileID: 5174908821584976142}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1

--- a/Assets/Scenes/Arkanoid.unity
+++ b/Assets/Scenes/Arkanoid.unity
@@ -575,293 +575,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9c6659e0e0077cf4980e94fd478695f1, type: 3}
---- !u!1 &136650167
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 136650170}
-  - component: {fileID: 136650169}
-  - component: {fileID: 136650168}
-  - component: {fileID: 136650171}
-  - component: {fileID: 136650173}
-  - component: {fileID: 136650174}
-  - component: {fileID: 136650175}
-  m_Layer: 9
-  m_Name: Paddle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &136650168
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 39f0b0311dcaded4ba76846899202f3f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  paddleData: {fileID: 11400000, guid: 36322b19fa0caf44187d2665012b83f8, type: 2}
-  rayDistance: 0
---- !u!212 &136650169
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 02b8e083c72759d4f8836b4ce3676f6c, type: 3}
-  m_Color: {r: 0, g: 1, b: 0.9758296, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.34, y: 2.73}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &136650170
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: -4.13, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 428214149}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!61 &136650171
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.0016640201, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.125, y: 1.0036764}
-    newSize: {x: 0.34, y: 2.73}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.14794911, y: 1}
-  m_EdgeRadius: 0
---- !u!114 &136650173
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9e47eecb573085f49919d7a2ad4c7cae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &136650174
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f2251b651ddeed2489815f26b026e905, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  trailSize: 8
-  spacing: 3
-  ghostMaterial: []
-  ghostSpriteSortingOrder: 0
-  renderOnMotion: 0
-  colorAlphaOverride: 0
-  alphaFluctuationOverride: 0.286
-  alphaFluctuationDivisor: 124
-  color: {r: 0, g: 1, b: 0.97647065, a: 0.46666667}
-  ghostPrefabType: 8
---- !u!96 &136650175
-TrailRenderer:
-  serializedVersion: 3
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136650167}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 0
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Time: 0.05
-  m_PreviewTimeScale: 1
-  m_Parameters:
-    serializedVersion: 3
-    widthMultiplier: 0.1
-    widthCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    colorGradient:
-      serializedVersion: 2
-      key0: {r: 0, g: 1, b: 0.97647065, a: 0.58431375}
-      key1: {r: 0, g: 0.582, b: 0.56830585, a: 0.41568628}
-      key2: {r: 0, g: 0, b: 0, a: 0}
-      key3: {r: 0, g: 0, b: 0, a: 0}
-      key4: {r: 0, g: 0, b: 0, a: 0}
-      key5: {r: 0, g: 0, b: 0, a: 0}
-      key6: {r: 0, g: 0, b: 0, a: 0}
-      key7: {r: 0, g: 0, b: 0, a: 0}
-      ctime0: 0
-      ctime1: 65535
-      ctime2: 0
-      ctime3: 0
-      ctime4: 0
-      ctime5: 0
-      ctime6: 0
-      ctime7: 0
-      atime0: 0
-      atime1: 36044
-      atime2: 0
-      atime3: 0
-      atime4: 0
-      atime5: 0
-      atime6: 0
-      atime7: 0
-      m_Mode: 0
-      m_ColorSpace: 0
-      m_NumColorKeys: 2
-      m_NumAlphaKeys: 2
-    numCornerVertices: 0
-    numCapVertices: 9
-    alignment: 0
-    textureMode: 0
-    textureScale: {x: 1, y: 1}
-    shadowBias: 0.5
-    generateLightingData: 0
-  m_MinVertexDistance: 0.24
-  m_MaskInteraction: 0
-  m_Autodestruct: 0
-  m_Emitting: 1
-  m_ApplyActiveColorSpace: 1
 --- !u!1001 &144306236
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2169,37 +1882,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9c6659e0e0077cf4980e94fd478695f1, type: 3}
---- !u!1 &428214148
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 428214149}
-  m_Layer: 9
-  m_Name: BallSpawnPoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &428214149
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 428214148}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.44, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 136650170}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &432796565
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7167,7 +6849,8 @@ PrefabInstance:
     - {fileID: 9212702855680048538, guid: 256ce6d02516a444ead2e06744852ea3, type: 3}
     - {fileID: 5190349869590758810, guid: 256ce6d02516a444ead2e06744852ea3, type: 3}
     - {fileID: -997520957604314842, guid: 256ce6d02516a444ead2e06744852ea3, type: 3}
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 5206222243746660079, guid: 256ce6d02516a444ead2e06744852ea3, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 256ce6d02516a444ead2e06744852ea3, type: 3}
@@ -7920,6 +7603,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 286622533507049269, guid: 9c6659e0e0077cf4980e94fd478695f1, type: 3}
   m_PrefabInstance: {fileID: 1877995916}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1919021516
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4623592075852294423, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_Name
+      value: Paddle
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.06
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5313984744809042107, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d805ac5fb1c33f4fbfc4457695235e6, type: 3}
 --- !u!4 &1921722213 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 286622533507049269, guid: 9c6659e0e0077cf4980e94fd478695f1, type: 3}
@@ -8800,8 +8540,8 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 519420032}
-  - {fileID: 136650170}
   - {fileID: 269182854}
+  - {fileID: 1919021516}
   - {fileID: 1709093775}
   - {fileID: 1751106415}
   - {fileID: 890664291}

--- a/Assets/Scripts/Controllers/Paddle/PaddleMovement.cs
+++ b/Assets/Scripts/Controllers/Paddle/PaddleMovement.cs
@@ -67,7 +67,8 @@ public class PaddleMovement : MonoBehaviour
         }
 
         //transform.Translate(0f, -1f * normalizedX * paddleData.Speed * Time.deltaTime * paddleData.MovementSensitivity, 0f);
-        transform.Translate(0f,-1f * normalizedX * paddleData.Speed * Time.deltaTime * paddleData.MovementSensitivity, 0f);
+        transform.Translate(normalizedX * paddleData.Speed * Time.deltaTime * paddleData.MovementSensitivity, 0f, 0f); //por si vuelves a girar el paddle a 90!!
+
         
 
     }

--- a/Assets/Scripts/PowerUp/PowerUp.cs
+++ b/Assets/Scripts/PowerUp/PowerUp.cs
@@ -52,7 +52,7 @@ public class PowerUp : MonoBehaviour
                         DeactivatePowerUp();
                 }
                 
-                collider.TryGetComponent<PaddleEffect>(out PaddleEffect paddle);
+                collider.TryGetComponent<PaddleMovement>(out PaddleMovement paddle);
                 if (paddle != null)
                 {
                     powerUpEffect.Execute(paddle.gameObject);

--- a/Assets/Scripts/Scriptable/BallData.asset
+++ b/Assets/Scripts/Scriptable/BallData.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: BallData
   m_EditorClassIdentifier: 
   speed: 2.5
-  collisionRadius: 0.1
+  collisionRadius: 0.125
   obstacleLayer:
     serializedVersion: 2
     m_Bits: 704


### PR DESCRIPTION
-Se cambiaron las fisicas de las personalidas a una guiada por CircleCast
-Se modifico el Paddle, añadiendole un hijo y pasando todo lo visual a este. El padre tien su rotación en 0,0,0
-Arkanoid Ball al igual que Paddle ahora tiene un hijo visual para evitar el escalado en el madre que causaba conflictos con fisicas
-Se añadio un efecto a la pelota cuando colisiona con el Paddle. Ahora el angulo de dirección depende de donde impacto con el Paddle

####
Conflictos:
-Al regresar el Paddle a rotación 0,0,0 va a generar alteración en los ejes del magnetometro
-Al crear un hijo visual en Paddle, los PowerUps no obtienen las refrencias correctas de las visuales (que antes tenia el padre)